### PR TITLE
Return empty string for null or empty inputs in reverse methods

### DIFF
--- a/src/com/jwetherell/algorithms/strings/StringFunctions.java
+++ b/src/com/jwetherell/algorithms/strings/StringFunctions.java
@@ -14,14 +14,20 @@ public class StringFunctions {
 
     public static final String reverseWithStringConcat(String string) {
         String output = new String();
-        for (int i = (string.length() - 1); i >= 0; i--) {
+        if (string == null || string.isEmpty()) {
+	    return output;
+	}
+	for (int i = (string.length() - 1); i >= 0; i--) {
             output += (string.charAt(i));
         }
         return output;
     }
 
     public static final String reverseWithStringBuilder(String string) {
-        final StringBuilder builder = new StringBuilder();
+	if (string == null || string.isEmpty()) {
+	    return new String();
+	}
+	final StringBuilder builder = new StringBuilder();
         for (int i = (string.length() - 1); i >= 0; i--) {
             builder.append(string.charAt(i));
         }


### PR DESCRIPTION
This PR contains changes to the reverseWithStringConcat and reverseWithStringBuilder methods of the StringFunctions class in com.jwetherell.algorithms.strings.

If the input to either of these methods is null or empty, the method will return a new, empty String object, allowing the method to gracefully exit instead of throwing an error.